### PR TITLE
Akka.Persistence tests

### DIFF
--- a/src/AkkaMemoryLeak/AkkaMemoryLeak.csproj
+++ b/src/AkkaMemoryLeak/AkkaMemoryLeak.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Akka.Cluster" Version="1.3.11" />
+    <PackageReference Include="Akka.Persistence" Version="1.3.11" />
   </ItemGroup>
 
 </Project>

--- a/src/AkkaMemoryLeak/Program.cs
+++ b/src/AkkaMemoryLeak/Program.cs
@@ -2,6 +2,7 @@
 using Akka.Actor;
 using Akka.Cluster;
 using Akka.Configuration;
+using Akka.Persistence;
 
 namespace AkkaMemoryLeak
 {
@@ -69,12 +70,14 @@ akka {
 }
 ";
 
-        class MyActor : ReceiveActor
+        class MyActor : ReceivePersistentActor
         {
             public MyActor()
             {
-                ReceiveAny(_ => Sender.Tell(_));
+                CommandAny(_ => Sender.Tell(_));
             }
+
+            public override string PersistenceId => Context.Self.Path.Name;
         }
 
     private static void CreateAndDisposeActorSystem(string configString)

--- a/src/AkkaMemoryLeak/Program.cs
+++ b/src/AkkaMemoryLeak/Program.cs
@@ -55,7 +55,7 @@ akka {
             unhandled: on
             router-misconfiguration: on
         }
-        provider = ""Akka.Cluster.ClusterActorRefProvider, Akka.Cluster""
+        #provider = ""Akka.Cluster.ClusterActorRefProvider, Akka.Cluster""
     }
     remote {
         helios.tcp {
@@ -89,13 +89,13 @@ akka {
                 system = ActorSystem.Create("ClusterServer", config);
             }
 
-            Cluster.Get(system).RegisterOnMemberUp(() =>
-            {
+            //Cluster.Get(system).RegisterOnMemberUp(() =>
+            //{
                 // ensure that a actor system did some work
                 var actor = system.ActorOf(Props.Create(() => new MyActor()));
                 var result = actor.Ask<ActorIdentity>(new Identify(42)).Result;
                 system.Terminate();
-            });
+            //});
 
             system.WhenTerminated.Wait();
             system.Dispose();


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/326939/54157736-eb59a200-4416-11e9-93dc-5787b17d35c3.png)

Verified it has same issues as Akka.Remote and Akka.Cluster - common culprit appears to be the `ForkJoinDispatcher`
